### PR TITLE
Throw errors to lifecycle so they can be handled

### DIFF
--- a/src/wrap-root-epic.js
+++ b/src/wrap-root-epic.js
@@ -23,7 +23,7 @@ export default function wrapRootEpic(rootEpic) {
       const epicsSubscription = rootEpic(actionsProxy, ...rest)
         .subscribe(
           action => results.next(action),
-          err => { throw err; },
+          err => lifecycle.error(err),
           () => lifecycle.complete()
         );
 


### PR DESCRIPTION
I'm not really sure what's the best way to go. But I wanted to be able to catch errors that occurs in my epics. And then handle them all using the same function.

So now it's possible from the `renderToString` method to hook a catch method which will get called when epics throws errors.