### PR TITLE
Update redux-observable to version 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7670,9 +7670,9 @@
       }
     },
     "redux-observable": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.16.0.tgz",
-      "integrity": "sha512-dFbcUOfIa78mV82muIrDC3K1iYjJ4q/muWklBMub4R9/6QVDwdRysph5+aV933rOUlJf74JSbxpbTO/FA2yKBA=="
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.17.0.tgz",
+      "integrity": "sha512-nVRl9KxdDNLKQRBkQK/svQIYDgTTDJbn3DEG6JB/DauZQs9bYl6R7b6ospXAS1zs6THarWHd3BhTTnGXFybVdA=="
     },
     "regenerate": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "redux": "^3.6.0",
-    "redux-observable": "^0.16.0",
+    "redux-observable": "^0.17.0",
     "rxjs": "^5.3.0"
   },
   "config": {


### PR DESCRIPTION
Hey, I updated redux-observable dependency to version 0.17.0

The tests run fine:
```
→ npm run test

> react-redux-epic@1.0.0 pretest /Users/jascha/dev/react-redux-epic
> npm run lint


> react-redux-epic@1.0.0 lint /Users/jascha/dev/react-redux-epic
> eslint src test


> react-redux-epic@1.0.0 test /Users/jascha/dev/react-redux-epic
> NODE_ENV=test nyc ava


  28 passed
---------------------|----------|----------|----------|----------|----------------|
File                 |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------|----------|----------|----------|----------|----------------|
All files            |    90.91 |    88.89 |    82.61 |    91.86 |                |
 contain.js          |    96.67 |     87.5 |      100 |    96.67 |            105 |
 index.js            |      100 |      100 |      100 |      100 |                |
 render-to-string.js |      100 |      100 |      100 |      100 |                |
 render.js           |        0 |      100 |        0 |        0 |... 12,13,16,19 |
 symbols.js          |      100 |      100 |      100 |      100 |                |
 wrap-root-epic.js   |      100 |      100 |      100 |      100 |                |
---------------------|----------|----------|----------|----------|----------------|

```